### PR TITLE
Fix GetDefaultComposition: guard against empty composition list.

### DIFF
--- a/pkg/functions/functions.jsonnet
+++ b/pkg/functions/functions.jsonnet
@@ -98,9 +98,10 @@
     ]
   ),
   GetDefaultComposition(compositions):: (
-    local default = [c.name for c in compositions if 'default' in c && c.default];
-    assert std.length(default) == 1 : 'Could not find a default composition. One composition must have default: true!';
-    default[0]
+    if std.length(compositions) > 0 then
+      local default = [c.name for c in compositions if 'default' in c && c.default];
+      assert std.length(default) == 1 : 'Could not find a default composition. One composition must have default: true!';
+      default[0]
   ),
   GetVersion(crd, version):: (
     local fv = [v for v in crd.spec.versions if 'name' in v && v.name == version];

--- a/pkg/functions/functions.jsonnet
+++ b/pkg/functions/functions.jsonnet
@@ -100,7 +100,7 @@
   GetDefaultComposition(compositions):: (
     if std.length(compositions) > 0 then
       local default = [c.name for c in compositions if 'default' in c && c.default];
-      assert std.length(default) == 1 : 'Could not find a default composition. One composition must have default: true!';
+      assert std.length(default) == 1 : 'Could not find a default composition. Exactly one composition must have default: true!';
       default[0]
   ),
   GetVersion(crd, version):: (


### PR DESCRIPTION
Signed-off-by: Cameron Boulton <cameron.boulton@calm.com>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes https://github.com/crossplane-contrib/x-generation/pull/26#issuecomment-1881631502

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
