### PR TITLE
update go to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   # Common versions
-  GO_VERSION: '1.18'
-  GOLANGCI_VERSION: 'v1.47.1'
+  GO_VERSION: '1.21'
+  GOLANGCI_VERSION: 'v1.56.2'
   DOCKER_BUILDX_VERSION: 'v0.8.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ CROSSPLANE_NAMESPACE = upbound-system
 NPROCS ?= 1
 
 GO_REQUIRED_VERSION ?= 1.21
+# GOLANGCILINT_VERSION is inherited from build submodule by default.
+# Uncomment below if you need to override the version.
+GOLANGCILINT_VERSION ?= 1.56.2
 
 # each of our test suites starts a kube-apiserver and running many test suites in
 # parallel can lead to high CPU utilization. by default we reduce the parallelism

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ CROSSPLANE_NAMESPACE = upbound-system
 # loading of this file
 NPROCS ?= 1
 
+GO_REQUIRED_VERSION ?= 1.21
+
 # each of our test suites starts a kube-apiserver and running many test suites in
 # parallel can lead to high CPU utilization. by default we reduce the parallelism
 # to half the number of CPU cores.


### PR DESCRIPTION

### Description of your changes

- Update go to use 1.21 instead of 1.19 in the build submodule
- update GOLANGCILINT_VERSION to 1.56.2


### How has this code been tested

`make reviewable test`