### PR TITLE
Feature/expose versions properties

### DIFF
--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -46,11 +46,10 @@ type XGenerator struct {
 	GeneratorConfig          t.GeneratorConfig
 	xrdSchema                *v1.JSONSchemaProps
 	overrideFieldDefinitions []*OverrideFieldDefinition
-	// feature/expose-versions-configs
+
 	Versions   []VersionConfig           `yaml:"versions" json:"versions"`
 }
 
-// feature/expose-versions-configs
 type VersionConfig struct {
     Name         string `yaml:"name" json:"name"`
     Served       bool   `yaml:"served" json:"served"`
@@ -98,8 +97,6 @@ func (g *XGenerator) GenerateXRD() (*c.CompositeResourceDefinition, error) {
 		return nil, err
 	}
 	g.xrdSchema = specSchema
-
-	// feature/expose-versions-configs
 
 	var crdVersions []c.CompositeResourceDefinitionVersion
 
@@ -168,7 +165,6 @@ func (g *XGenerator) GenerateXRD() (*c.CompositeResourceDefinition, error) {
 				Plural:     "composite" + plural,
 				Categories: g.generateCategories(),
 			},
-			// feature/expose-versions-configs
 			Versions: crdVersions,
 		},
 	}

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -136,7 +136,6 @@ func (g *XGenerator) GenerateXRD() (*c.CompositeResourceDefinition, error) {
 	}
 
 	//
-
 	// g.generateSchema()
 	//
 

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -46,14 +46,6 @@ type XGenerator struct {
 	GeneratorConfig          t.GeneratorConfig
 	xrdSchema                *v1.JSONSchemaProps
 	overrideFieldDefinitions []*OverrideFieldDefinition
-
-	Versions   []VersionConfig           `yaml:"versions" json:"versions"`
-}
-
-type VersionConfig struct {
-    Name         string `yaml:"name" json:"name"`
-    Served       bool   `yaml:"served" json:"served"`
-    Referenceable bool   `yaml:"referenceable" json:"referenceable"`
 }
 
 type OverrideFieldDefinition struct {
@@ -78,6 +70,7 @@ func (g *XGenerator) GenerateXRD() (*c.CompositeResourceDefinition, error) {
 
 	plural := g.nameToPlural()
 	defaultCompositionName, _ := g.getDefaultCompositionName()
+	version, _ := g.getVersion()
 	status, err := g.generateSchema("status")
 	if err != nil {
 		return nil, err
@@ -97,52 +90,6 @@ func (g *XGenerator) GenerateXRD() (*c.CompositeResourceDefinition, error) {
 		return nil, err
 	}
 	g.xrdSchema = specSchema
-
-	var crdVersions []c.CompositeResourceDefinitionVersion
-
-	// default Version configs
-	defaultVersion := c.CompositeResourceDefinitionVersion {
-		Name:          g.Version,
-		Referenceable: true,
-		Served:        true,
-		Schema: &c.CompositeResourceValidation {
-			OpenAPIV3Schema: runtime.RawExtension {
-				Object: &unstructured.Unstructured {
-					Object: map[string]interface{} {
-						"properties": map[string]interface{} {
-							"spec":   g.xrdSchema,
-							"status": status,
-						},
-					},
-				},
-			},
-		},
-	}
-	crdVersions = []c.CompositeResourceDefinitionVersion{defaultVersion}
-
-	if g.Versions != nil && len(g.Versions) > 0 {
-		crdVersions = nil // Clear the default version if there are custom versions
-		for _, version := range g.Versions {
-			crdVersions = append(crdVersions, c.CompositeResourceDefinitionVersion{
-				Name:          version.Name,
-				Referenceable: version.Referenceable,
-				Served:        version.Served,
-				Schema: &c.CompositeResourceValidation {
-					OpenAPIV3Schema: runtime.RawExtension {
-						Object: &unstructured.Unstructured {
-							Object: map[string]interface{} {
-								"properties": map[string]interface{} {
-									"spec":   g.xrdSchema,
-									"status": status,
-								},
-							},
-						},
-					},
-				},
-			})
-		}
-	}
-
 	xrd := c.CompositeResourceDefinition{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apiextensions.crossplane.io/v1",
@@ -165,7 +112,26 @@ func (g *XGenerator) GenerateXRD() (*c.CompositeResourceDefinition, error) {
 				Plural:     "composite" + plural,
 				Categories: g.generateCategories(),
 			},
-			Versions: crdVersions,
+			Versions: []c.CompositeResourceDefinitionVersion {
+				{
+					Name:          g.Version,
+					Referenceable: true,
+					Served:        true,
+					Schema: &c.CompositeResourceValidation {
+						OpenAPIV3Schema: runtime.RawExtension {
+							Object: &unstructured.Unstructured {
+								Object: map[string]interface{} {
+									"properties": map[string]interface{} {
+										"spec":   g.xrdSchema,
+										"status": status,
+									},
+								},
+							},
+						},
+					},
+					AdditionalPrinterColumns: filterCustomResourceColumnDefinitions(version.AdditionalPrinterColumns),
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Thank you for helping to improve Crossplane!

Please be sure to search for open issues before raising a new one. We use issues
for bug reports and feature requests. Please find us at https://slack.crossplane.io
for questions, support, and discussion.
-->

### What happened?
The generated XRD always ends up having `referenceable: false`:
```yaml
versions:
  - name: v1alpha1
    referenceable: false
```
which leads to a CRD with `storage: false`:
```yaml
versions:
  - additionalPrinterColumns:
    # ...
    name: v1alpha1
    schema:
    # ...
    served: true
    storage: false
```
which causing the following error during the applying of the CRD:
```
cannot establish control of object: admission webhook "compositeresourcedefinitions.apiextensions.crossplane.io" denied the request: invalid CRD generated for CompositeResourceDefinition: CustomResourceDefinition.apiextensions.k8s.io "compositedbclusters.rds.aws.xxx.cloud" is invalid: [spec.versions: Invalid value: []apiextensions.CustomResourceDefinitionVersion{apiextensions.CustomResourceDefinitionVersion{Name:"v1alpha1", Served:true, Storage:false, Deprecated:false, DeprecationWarning:(*string)(nil), Schema:(*apiextensions.CustomResourceValidation)(nil), Subresources:(*apiextensions.CustomResourceSubresources)(nil), AdditionalPrinterColumns:[]apiextensions.CustomResourceColumnDefinition(nil)}}: must have exactly one version marked as storage version, status.storedVersions: Invalid value: []string(nil): must have at least one stored version]
```

### How I solved the issue locally?
- I passed the versions details in the generate.yaml file:
```yaml 
versions:
  - name: v1alpha1
    served: true
    referenceable: true
```

- then I used the passed values in the generator
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
