### PR TITLE
feat(local-configuration): added defaultCompositeDeletePolicy property

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
@@ -144,7 +144,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
@@ -204,7 +204,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-e2e-tests-${{ hashFiles('**/go.sum') }}
@@ -265,7 +265,7 @@ jobs:
         run: echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT
 
       - name: Cache the Go Build Cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ${{ steps.go.outputs.cache }}
           key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The local configuration is placed in the subfolder of the composition to be crea
 | overrideFieldsInClaim          | object                | This optional property can be used to override the names in the composite and the claim or add properties. See description below |
 | patchName                      | boolean               | If set to false, the name of the object will not be patched, otherwise`patchExternalName` decides if the name of the claim will be patched to `metadata.name` or `metadata.annotations[crossplane.io/external-name]` |
 | patchExternalName              | boolean               | Decides if if the name of the claim will be patched to `metadata.name` or `metadata.annotations[crossplane.io/external-name]`. Not applied if `patchName` is false |
-| defaultCompositeDeletePolicy   | string                | This optional property can be used to set the defaultCompositeDeletePolicy on the xrd, possible values Foreground or Background, The default value is defaultCompositeDeletePolicy: Background |
+| defaultCompositeDeletePolicy   | string                | This optional property can be used to set the defaultCompositeDeletePolicy on the xrd, possible values Foreground or Background |
 
 
 ## overrideFieldsInClaim

--- a/README.md
+++ b/README.md
@@ -87,8 +87,9 @@ The local configuration is placed in the subfolder of the composition to be crea
 | tags.globalHandling.fromLabels | "append" or "replace" | If append, the tags in tags.fromLabels are appended to the tags in the global configuration tags.fromLabels, otherwise those will be replaced |
 | tags.globalHandling.common     | "append" or "replace" | If append, the tags in labels.common are appended to the tasg in the global configuration tags.common, otherwise those will be replaced |
 | overrideFieldsInClaim          | object                | This optional property can be used to override the names in the composite and the claim or add properties. See description below |
-| patchName          | boolean                | If set to false, the name of the object will not be patched, otherwise`patchExternalName` decides if the name of the claim will be patched to `metadata.name` or `metadata.annotations[crossplane.io/external-name]` |
-| patchExternalName          | boolean                | Decides if if the name of the claim will be patched to `metadata.name` or `metadata.annotations[crossplane.io/external-name]`. Not applied if `patchName` is false |
+| patchName                      | boolean               | If set to false, the name of the object will not be patched, otherwise`patchExternalName` decides if the name of the claim will be patched to `metadata.name` or `metadata.annotations[crossplane.io/external-name]` |
+| patchExternalName              | boolean               | Decides if if the name of the claim will be patched to `metadata.name` or `metadata.annotations[crossplane.io/external-name]`. Not applied if `patchName` is false |
+| defaultCompositeDeletePolicy   | string                | This optional property can be used to set the defaultCompositeDeletePolicy on the xrd, possible values Foreground or Background, The default value is defaultCompositeDeletePolicy: Background |
 
 
 ## overrideFieldsInClaim

--- a/pkg/generator/generator.go
+++ b/pkg/generator/generator.go
@@ -20,28 +20,29 @@ import (
 )
 
 type XGenerator struct {
-	Group                     string                      `yaml:"group" json:"group"`
-	Name                      string                      `yaml:"name" json:"name"`
-	Plural                    *string                     `yaml:"plural,omitempty" json:"plural,omitempty"`
-	PatchExternalName         *bool                       `yaml:"patchExternalName,omitempty" json:"patchExternalName,omitempty"`
-	PatchlName                *bool                       `yaml:"patchName,omitempty" json:"patchName,omitempty"`
-	ConnectionSecretKeys      *[]string                   `yaml:"connectionSecretKeys,omitempty" json:"connectionSecretKeys,omitempty"`
-	Compositions              []t.Composition             `yaml:"compositions" json:"compositions"`
-	Version                   string                      `yaml:"version" json:"version"`
-	Crd                       v1.CustomResourceDefinition `yaml:"crd" json:"crd"`
-	Provider                  t.ProviderConfig            `yaml:"provider" json:"provider"`
-	OverrideFields            []t.OverrideField           `yaml:"overrideFields" json:"overrideFields"`
-	OverrideFieldsInClaim     []t.OverrideFieldInClaim    `yaml:"overrideFieldsInClaim" json:"overrideFieldsInClaim"`
-	Labels                    t.LocalLabelConfig          `yaml:"labels,omitempty" json:"labels,omitempty"`
-	ReadinessChecks           *bool                       `yaml:"readinessChecks,omitempty" json:"readinessChecks,omitempty"`
-	ResourceName              *string                     `yaml:"resourceName,omitempty" json:"resourceName,omitempty"`
-	UIDFieldPath              *string                     `yaml:"uidFieldPath,omitempty" json:"uidFieldPath,omitempty"`
-	ExpandCompositionName     *bool                       `yaml:"expandCompositionName,omitempty" json:"expandCompositionName,omitempty"`
-	AdditionalPipelineSteps   []t.PipelineStep            `yaml:"additionalPipelineSteps,omitempty" json:"additionalPipelineSteps,omitempty"`
-	TagType                   *string                     `yaml:"tagType,omitempty" json:"tagType,omitempty"`
-	TagProperty               *string                     `yaml:"tagProperty,omitempty" json:"tagProperty,omitempty"`
-	AutoReadyFunction         *t.AutoReadyFunction        `yaml:"autoReadyFunction,omitempty" json:"autoReadyFunction,omitempty"`
-	PatchAndTransfromFunction *string                     `yaml:"patchAndTransfromFunction,omitempty" json:"patchAndTransfromFunction,omitempty"`
+	Group                        string                      `yaml:"group" json:"group"`
+	Name                         string                      `yaml:"name" json:"name"`
+	Plural                       *string                     `yaml:"plural,omitempty" json:"plural,omitempty"`
+	PatchExternalName            *bool                       `yaml:"patchExternalName,omitempty" json:"patchExternalName,omitempty"`
+	PatchlName                   *bool                       `yaml:"patchName,omitempty" json:"patchName,omitempty"`
+	ConnectionSecretKeys         *[]string                   `yaml:"connectionSecretKeys,omitempty" json:"connectionSecretKeys,omitempty"`
+	Compositions                 []t.Composition             `yaml:"compositions" json:"compositions"`
+	Version                      string                      `yaml:"version" json:"version"`
+	Crd                          v1.CustomResourceDefinition `yaml:"crd" json:"crd"`
+	Provider                     t.ProviderConfig            `yaml:"provider" json:"provider"`
+	OverrideFields               []t.OverrideField           `yaml:"overrideFields" json:"overrideFields"`
+	OverrideFieldsInClaim        []t.OverrideFieldInClaim    `yaml:"overrideFieldsInClaim" json:"overrideFieldsInClaim"`
+	Labels                       t.LocalLabelConfig          `yaml:"labels,omitempty" json:"labels,omitempty"`
+	ReadinessChecks              *bool                       `yaml:"readinessChecks,omitempty" json:"readinessChecks,omitempty"`
+	ResourceName                 *string                     `yaml:"resourceName,omitempty" json:"resourceName,omitempty"`
+	UIDFieldPath                 *string                     `yaml:"uidFieldPath,omitempty" json:"uidFieldPath,omitempty"`
+	ExpandCompositionName        *bool                       `yaml:"expandCompositionName,omitempty" json:"expandCompositionName,omitempty"`
+	AdditionalPipelineSteps      []t.PipelineStep            `yaml:"additionalPipelineSteps,omitempty" json:"additionalPipelineSteps,omitempty"`
+	TagType                      *string                     `yaml:"tagType,omitempty" json:"tagType,omitempty"`
+	TagProperty                  *string                     `yaml:"tagProperty,omitempty" json:"tagProperty,omitempty"`
+	AutoReadyFunction            *t.AutoReadyFunction        `yaml:"autoReadyFunction,omitempty" json:"autoReadyFunction,omitempty"`
+	PatchAndTransfromFunction    *string                     `yaml:"patchAndTransfromFunction,omitempty" json:"patchAndTransfromFunction,omitempty"`
+	DefaultCompositeDeletePolicy *string                     `yaml:"defaultCompositeDeletePolicy,omitempty" json:"defaultCompositeDeletePolicy,omitempty"`
 
 	GlobalLabels             []string
 	GeneratorConfig          t.GeneratorConfig

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -712,7 +712,6 @@ func parseArgs(configFile, generatorFile, inputPath, scriptFile, scriptPath, out
 	if err != nil {
 		return err
 	}
-	
 	_, b, _, ok := runtime.Caller(0)
 	if !ok {
 		return errors.New("Unable to get generator module path")

--- a/pkg/main_test.go
+++ b/pkg/main_test.go
@@ -2703,3 +2703,295 @@ func Test_noDefaultPatch(t *testing.T) {
 		}
 	})
 }
+
+func Test_setDefaultCompositeDeletePolicy_Foreground(t *testing.T) {
+	type args struct {
+		crd     extv1.CustomResourceDefinition
+		version string
+	}
+	testData := struct {
+		name string
+		args args
+	}{
+
+		name: "Should set default composite delete policy to Foreground",
+		args: args{
+			crd: extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Versions: []extv1.CustomResourceDefinitionVersion{
+						{
+							Name: "testv1",
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{{
+								JSONPath: ".metadata.annotations.crossplane.io/external-name",
+								Name:     "EXTERNAL-NAME",
+								Type:     "string",
+							}},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Properties: map[string]extv1.JSONSchemaProps{
+										"spec": {
+											Properties: map[string]extv1.JSONSchemaProps{
+												"providerConfigRef": {
+													Default: &extv1.JSON{
+														Raw: []byte("{\"name\": \"default\"}"),
+													},
+													Description: "ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {
+															Type:        "string",
+															Description: "Name of the referenced object.",
+														},
+														"policy": {
+															Type:        "string",
+															Description: "description: Policies for referencing.",
+														},
+													},
+												},
+											},
+										},
+										"status": {
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type: "string",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			version: "v1alpha1",
+		},
+	}
+	t.Run(testData.name, func(t *testing.T) {
+
+		crdSource, err := json.Marshal(testData.args.crd)
+		if err != nil {
+			t.Errorf("could not marshal crdSource")
+		}
+		tempDir, err := os.MkdirTemp("", "g-generation*")
+		if err != nil {
+			t.Errorf("could not generate tempDir")
+		}
+		plural := "TestObjects"
+		g := Generator{
+			Group:       "example.cloud",
+			Name:        "TestObject",
+			Version:     "testv1",
+			crdSource:   string(crdSource),
+			configPath:  tempDir,
+			TagType:     nil,
+			TagProperty: nil,
+			Provider: xtype.ProviderConfig{
+				CRD: xtype.CrdConfig{
+					Version: "testv1",
+				},
+			},
+			Plural: &plural,
+			Compositions: []xtype.Composition{
+				{
+					Name:     "configuration",
+					Provider: "sop",
+					Default:  true,
+				},
+			},
+			OverrideFields:        []xtype.OverrideField{},
+			OverrideFieldsInClaim: []xtype.OverrideFieldInClaim{},
+			DefaultCompositeDeletePolicy: func() *string { s := "Foreground"; return &s }(),
+		}
+
+		gConfig := xtype.GeneratorConfig{
+			CompositionIdentifier: "example.cloud",
+		}
+
+		cwd, _ := os.Getwd()
+
+		sp := filepath.Join(cwd, "functions")
+		g.Exec(&gConfig, sp, "", "")
+
+		path := filepath.Join(tempDir, "definition.yaml")
+		y, err := os.ReadFile(path)
+
+		if err != nil {
+			t.Errorf("could not load definition.yaml file")
+		}
+
+		var newCRD cv1.CompositeResourceDefinition
+			err = yaml.Unmarshal(y, &newCRD)
+
+		if err != nil {
+			t.Errorf("could not parse definition.yaml file")
+		}
+
+		// assert that the default composite delete policy is set to Foreground
+		if newCRD.Spec.DefaultCompositeDeletePolicy != nil {
+			if *newCRD.Spec.DefaultCompositeDeletePolicy != "Foreground" {
+				t.Errorf("expected default composite delete policy to be Foreground, got %s", *newCRD.Spec.DefaultCompositeDeletePolicy)
+			}
+		}
+
+		err = os.Remove(path)
+		if err != nil {
+			t.Error("could not delete definition file")
+		}
+		definitionPath := filepath.Join(tempDir, "composition-configuration.yaml")
+		err = os.Remove(definitionPath)
+		if err != nil {
+			t.Error("could not delete composition file")
+		}
+		err = os.Remove(tempDir)
+		if err != nil {
+			t.Error("could not delete temp directory")
+		}
+	})
+}
+
+func Test_setDefaultCompositeDeletePolicy_Background(t *testing.T) {
+	type args struct {
+		crd     extv1.CustomResourceDefinition
+		version string
+	}
+	testData := struct {
+		name string
+		args args
+	}{
+
+		name: "Should set default composite delete policy to Background",
+		args: args{
+			crd: extv1.CustomResourceDefinition{
+				Spec: extv1.CustomResourceDefinitionSpec{
+					Versions: []extv1.CustomResourceDefinitionVersion{
+						{
+							Name: "testv1",
+							AdditionalPrinterColumns: []extv1.CustomResourceColumnDefinition{{
+								JSONPath: ".metadata.annotations.crossplane.io/external-name",
+								Name:     "EXTERNAL-NAME",
+								Type:     "string",
+							}},
+							Schema: &extv1.CustomResourceValidation{
+								OpenAPIV3Schema: &extv1.JSONSchemaProps{
+									Properties: map[string]extv1.JSONSchemaProps{
+										"spec": {
+											Properties: map[string]extv1.JSONSchemaProps{
+												"providerConfigRef": {
+													Default: &extv1.JSON{
+														Raw: []byte("{\"name\": \"default\"}"),
+													},
+													Description: "ProviderConfigReference specifies how the provider that will be used to create, observe, update, and delete this managed",
+													Type:        "object",
+													Properties: map[string]extv1.JSONSchemaProps{
+														"name": {
+															Type:        "string",
+															Description: "Name of the referenced object.",
+														},
+														"policy": {
+															Type:        "string",
+															Description: "description: Policies for referencing.",
+														},
+													},
+												},
+											},
+										},
+										"status": {
+											Properties: map[string]extv1.JSONSchemaProps{
+												"name": {
+													Type: "string",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			version: "v1alpha1",
+		},
+	}
+	t.Run(testData.name, func(t *testing.T) {
+
+		crdSource, err := json.Marshal(testData.args.crd)
+		if err != nil {
+			t.Errorf("could not marshal crdSource")
+		}
+		tempDir, err := os.MkdirTemp("", "g-generation*")
+		if err != nil {
+			t.Errorf("could not generate tempDir")
+		}
+		plural := "TestObjects"
+		g := Generator{
+			Group:       "example.cloud",
+			Name:        "TestObject",
+			Version:     "testv1",
+			crdSource:   string(crdSource),
+			configPath:  tempDir,
+			TagType:     nil,
+			TagProperty: nil,
+			Provider: xtype.ProviderConfig{
+				CRD: xtype.CrdConfig{
+					Version: "testv1",
+				},
+			},
+			Plural: &plural,
+			Compositions: []xtype.Composition{
+				{
+					Name:     "configuration",
+					Provider: "sop",
+					Default:  true,
+				},
+			},
+			OverrideFields:        []xtype.OverrideField{},
+			OverrideFieldsInClaim: []xtype.OverrideFieldInClaim{},
+			DefaultCompositeDeletePolicy: func() *string { s := "Background"; return &s }(),
+		}
+
+		gConfig := xtype.GeneratorConfig{
+			CompositionIdentifier: "example.cloud",
+		}
+
+		cwd, _ := os.Getwd()
+
+		sp := filepath.Join(cwd, "functions")
+		g.Exec(&gConfig, sp, "", "")
+
+		path := filepath.Join(tempDir, "definition.yaml")
+		y, err := os.ReadFile(path)
+
+		if err != nil {
+			t.Errorf("could not load definition.yaml file")
+		}
+
+		var newCRD cv1.CompositeResourceDefinition
+			err = yaml.Unmarshal(y, &newCRD)
+
+		if err != nil {
+			t.Errorf("could not parse definition.yaml file")
+		}
+
+		// assert that the default composite delete policy is set to Background
+		if newCRD.Spec.DefaultCompositeDeletePolicy != nil {
+			if *newCRD.Spec.DefaultCompositeDeletePolicy != "Background" {
+				t.Errorf("expected default composite delete policy to be Background, got %s", *newCRD.Spec.DefaultCompositeDeletePolicy)
+			}
+		}
+
+		err = os.Remove(path)
+		if err != nil {
+			t.Error("could not delete definition file")
+		}
+		definitionPath := filepath.Join(tempDir, "composition-configuration.yaml")
+		err = os.Remove(definitionPath)
+		if err != nil {
+			t.Error("could not delete composition file")
+		}
+		err = os.Remove(tempDir)
+		if err != nil {
+			t.Error("could not delete temp directory")
+		}
+	})
+}


### PR DESCRIPTION
### Description of your changes

Added local configuration `defaultCompositeDeletePolicy` property.

Fixes https://github.com/crossplane-contrib/x-generation/issues/41

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

The MR can be tested adding `defaultCompositeDeletePolicy: Foreground` to a generate.yaml and execute the gerenation and the `defaultCompositeDeletePolicy: Foreground` should be added to the output xrd definition.yaml.

gerenate.yaml
```yaml
group: dms.aws.example
name: Endpoint
version: v1beta1
provider:
  baseURL: https://raw.githubusercontent.com/upbound/%s/%s/package/crds/%s
  name: provider-aws
  version: main
  crd:
    file: dms.aws.upbound.io_endpoints.yaml
    version: v1beta1
patchExternalName: false
defaultCompositeDeletePolicy: Foreground
compositions:
  - name: compositeendpoint.dms.aws.example
    provider: example
    default: true
```

expected definition.yaml
```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: compositeendpoints.dms.aws.example
spec:
  defaultCompositeDeletePolicy: Foreground
  claimNames:
    kind: Endpoint
    plural: endpoints
  defaultCompositionRef:
    name: compositeendpoint.dms.aws.example
  group: dms.aws.example
```