### PR TITLE
fix: add defaultCompositeDeletePolicy functionality to pipeline mode compositions

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -490,6 +490,15 @@ func (g *Generator) Exec(generatorConfig *t.GeneratorConfig, scriptPath, scriptF
 		if err != nil {
 			log.Fatalf("Error creating xrd: %v", err)
 		}
+
+		// add defaultCompositeDeletePolicy property if its set
+		if g.DefaultCompositeDeletePolicy != nil {
+			_, err := g.setDefaultCompositeDeletePolicy(xrd)
+			if err != nil {
+				fmt.Printf("Error updating defaultCompositeDeletePolicy: %v", err)
+			}
+		}
+
 		rawContent, err := json.Marshal(xrd.Spec.Versions[0].Schema.OpenAPIV3Schema.Object)
 		if err != nil {
 			fmt.Printf("Error marhalling object: %v", err)


### PR DESCRIPTION
### Description of your changes

The local configuration defaultCompositeDeletePolicy was not available for pipeline mode compositions. This PR add it.

Fixes #50

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Sample configuration:

generator-config.yaml
```yaml
compositionIdentifier: example.cloud
provider:
  baseURL: https://raw.githubusercontent.com/crossplane-contrib/%s/%s/package/crds/%s
provider-aws
  name: provider-aws
  version: "v0.44.2"
usePipeline: true
```

generate.yaml
```yaml
group: dms.aws.dkb.cloud
name: Endpoint
version: v1beta1
provider:
  baseURL: https://raw.githubusercontent.com/upbound/%s/%s/package/crds/%s
  name: provider-aws
  version: main
  crd:
    file: dms.aws.upbound.io_endpoints.yaml
    version: v1beta1
patchExternalName: false
defaultCompositeDeletePolicy: Foreground
compositions:
  - name: compositeendpoint.dms.aws.example
    provider: example
    default: true
```

Expected definition.yaml
```yaml
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: compositeendpoints.dms.aws.example
spec:
  defaultCompositeDeletePolicy: Foreground
  claimNames:
    kind: Endpoint
    plural: endpoints
  defaultCompositionRef:
    name: compositeendpoint.dms.aws.example
  group: dms.aws.dkb.example
```